### PR TITLE
refactor: introduce single result class

### DIFF
--- a/Src/SampleConsoleApp/Program.cs
+++ b/Src/SampleConsoleApp/Program.cs
@@ -62,29 +62,29 @@ static async Task TestZamupayAPIAsync(IServiceProvider services)
 
     var zamupayRoutes = await _zamupayService.GetZamupayRoutesAsync(10);
 
-    if (zamupayRoutes.Item2 != null)
+    if (!zamupayRoutes.Succeeded)
     {
-        Console.WriteLine(zamupayRoutes.Item2.ToString());
+        Console.WriteLine(zamupayRoutes!.Errors!.FirstOrDefault()!.Status);
     }
     else
     {
-        if (zamupayRoutes.Item1 != null)
+        if (zamupayRoutes.Succeeded)
         {
-            routes = zamupayRoutes.Item1.Routes.ToArray();
+            routes = zamupayRoutes.Items!.Routes.ToArray();
 
             Console.WriteLine(routes?.FirstOrDefault()?.RouteIntergration);
 
-            var zamupayRouteChannelTypes = await _zamupayService.GetZamupayRouteChannelTypesAsync(Guid.Parse(zamupayRoutes.Item1.Routes[0].Id), 10);
+            var zamupayRouteChannelTypes = await _zamupayService.GetZamupayRouteChannelTypesAsync(Guid.Parse(routes![0].Id), 10);
 
-            if (zamupayRouteChannelTypes.Item2 != null)
+            if (!zamupayRouteChannelTypes.Succeeded)
             {
-                Console.WriteLine(zamupayRouteChannelTypes.Item2.ToString());
+                Console.WriteLine(zamupayRouteChannelTypes!.Errors!.FirstOrDefault()!.Status);
             }
             else
             {
-                if (zamupayRouteChannelTypes.Item1 != null)
+                if (zamupayRouteChannelTypes.Succeeded)
                 {
-                    channelTypes = zamupayRouteChannelTypes.Item1.ToArray();
+                    channelTypes = zamupayRouteChannelTypes.Items?.ToArray();
 
                     Console.WriteLine(channelTypes?.FirstOrDefault()?.ChannelDescription);
                 }
@@ -92,19 +92,19 @@ static async Task TestZamupayAPIAsync(IServiceProvider services)
 
             var categories = new List<string>();
 
-            foreach (var item in zamupayRoutes.Item1.Routes)
+            foreach (var item in zamupayRoutes.Items!.Routes)
             {
                 var zamupayRoute = await _zamupayService.GetZamupayRouteAsync(Guid.Parse(item.Id), 10);
 
-                if (zamupayRoute.Item2 != null)
+                if (!zamupayRoute.Succeeded)
                 {
-                    Console.WriteLine(zamupayRoute.Item2.ToString());
+                    Console.WriteLine(zamupayRoute!.Errors!.FirstOrDefault()!.Status);
                 }
                 else
                 {
-                    if (zamupayRoute.Item1 != null)
+                    if (zamupayRoute.Succeeded)
                     {
-                        Console.WriteLine(zamupayRoute.Item1.CategoryDescription);
+                        Console.WriteLine(zamupayRoute.Items?.CategoryDescription);
                     }
                 }
 
@@ -115,15 +115,15 @@ static async Task TestZamupayAPIAsync(IServiceProvider services)
             {
                 var zamupayRouteByCategories = await _zamupayService.GetZamupayRoutesByCategoryAsync(categories[0], 10);
 
-                if (zamupayRouteByCategories.Item2 != null)
+                if (!zamupayRouteByCategories.Succeeded)
                 {
-                    Console.WriteLine(zamupayRouteByCategories.Item2.ToString());
+                    Console.WriteLine(zamupayRouteByCategories!.Errors!.FirstOrDefault()!.Status);
                 }
                 else
                 {
-                    if (zamupayRouteByCategories.Item1 != null)
+                    if (zamupayRouteByCategories.Succeeded)
                     {
-                        Console.WriteLine(zamupayRouteByCategories.Item1?.FirstOrDefault()?.RouteIntergration);
+                        Console.WriteLine(zamupayRouteByCategories.Items?.FirstOrDefault()?.RouteIntergration);
                     }
                 }
             }

--- a/Src/SampleConsoleApp/Program.cs
+++ b/Src/SampleConsoleApp/Program.cs
@@ -52,12 +52,12 @@ static async Task TestZamupayAPIAsync(IServiceProvider services)
 
     var auth = await _zamupayService.GetZamupayIdentityServerAuthTokenAsync();
 
-    if (!string.IsNullOrWhiteSpace(auth.Item1?.AccessToken))
+    if (!string.IsNullOrWhiteSpace(auth.Items?.AccessToken))
     {
-        token = auth.Item1.AccessToken;
-        expiresIn = auth.Item1.ExpiresIn;
+        token = auth.Items.AccessToken;
+        expiresIn = auth.Items.ExpiresIn;
         requestDateTime = DateTime.Now;
-        Console.WriteLine(auth.Item1.AccessToken);
+        Console.WriteLine(auth.Items.AccessToken);
     }
 
     var zamupayRoutes = await _zamupayService.GetZamupayRoutesAsync(10);
@@ -134,35 +134,35 @@ static async Task TestZamupayAPIAsync(IServiceProvider services)
 
             var createBillPaymentResult = await _zamupayService.PostBillPaymentAsync(billPayment);
 
-            if (createBillPaymentResult.Item2 != null)
+            if (!createBillPaymentResult.Succeeded)
             {
-                Console.WriteLine(createBillPaymentResult.Item2.ToString());
+                Console.WriteLine(createBillPaymentResult.Errors!.FirstOrDefault()!.Status);
             }
             else
             {
-                if (createBillPaymentResult.Item1 != null)
+                if (createBillPaymentResult.Succeeded)
                 {
                     var transactionQueryModelDTO = new TransactionQueryModelDTO
                     {
-                        Id = createBillPaymentResult.Item1?.Message?.OriginatorConversationId,
+                        Id = createBillPaymentResult.Items!.Message!.OriginatorConversationId,
                         IdType = PaymentIdTypeEnum.OriginatorConversationId
                     };
 
                     var billPaymentQueryResult = await _zamupayService.GetBillPaymentAsync(transactionQueryModelDTO);
 
-                    if (billPaymentQueryResult.Item2 != null)
+                    if (!billPaymentQueryResult.Succeeded)
                     {
-                        Console.WriteLine(billPaymentQueryResult.Item2.ToString());
+                        Console.WriteLine(billPaymentQueryResult.Errors!.FirstOrDefault()!.Status);
                     }
                     else
                     {
-                        if (billPaymentQueryResult.Item1 != null)
+                        if (billPaymentQueryResult.Succeeded)
                         {
-                            Console.WriteLine(billPaymentQueryResult.Item1?.SystemConversationId);
+                            Console.WriteLine(billPaymentQueryResult.Items?.SystemConversationId);
                         }
                     }
 
-                    Console.WriteLine(createBillPaymentResult.Item1?.Message?.DueAmount);
+                    Console.WriteLine(createBillPaymentResult.Items?.Message?.DueAmount);
                 }
             }
         }

--- a/Src/ZamuPay.API/DTOs/ZamuApiResult.cs
+++ b/Src/ZamuPay.API/DTOs/ZamuApiResult.cs
@@ -1,0 +1,61 @@
+﻿using System.Collections.Generic;
+
+namespace ZamuPay.API.DTOs
+{
+    public class ZamuApiResult<T> where T : class
+    {
+        private readonly List<ErrorDetailDTO> _errors = new List<ErrorDetailDTO>();
+
+        /// <summary>
+        /// Flag indicating whether an operation succeeded or not. The default is false.
+        /// </summary>
+        public bool Succeeded { get; set; } = false;
+
+
+        /// <summary>
+        /// Represents an item[s] retrieved if and only if Suceeded is true otherwise it is null.
+        /// </summary>
+        public T? Items { get; set; }
+
+        /// <summary>
+        /// A list of <see cref="ErrorDetailDTO"/> instance containing errors from the ZamuPay service.
+        /// </summary>
+        public List<ErrorDetailDTO>? Errors => _errors;
+
+
+        /// <summary>
+        /// Handle successful operation returning with an optional object item.
+        /// </summary>
+        /// <param name="items"> An object</param>
+        /// <returns>A <see cref="ZamuApiResult"/> indicating a successful operation </returns>
+
+        public ZamuApiResult<T> Success(T? items)
+        {
+            var result = new ZamuApiResult<T> { Succeeded = true };
+
+            if (items != null)
+            {
+                result.Items = items;
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Handle failed operation with an optional <see cref="List{T}"/> of errors.
+        /// </summary>
+        /// <param name="errors"> An optional <see cref="List{T}"/> of <see cref="ErrorDetailDTO"/> instance</param>
+        /// <returns>A <see cref="ZamuApiResult"/> indicating a failed operation</returns>
+
+        public ZamuApiResult<T> Failed(List<ErrorDetailDTO>? errors) {
+
+            var result = new ZamuApiResult<T> { Succeeded = false };
+
+            if(errors != null)
+            {
+                result._errors.AddRange(errors);
+            }
+
+            return result;
+        }
+    }
+}

--- a/Src/ZamuPay.API/Interfaces/IZamupayService.cs
+++ b/Src/ZamuPay.API/Interfaces/IZamupayService.cs
@@ -17,13 +17,13 @@ namespace ZamuPay.API.Interfaces
 
         #region Routes
 
-        public Task<(ZamupayRoutesDTO?, ErrorDetailDTO)> GetZamupayRoutesAsync(int expirationTime, CancellationToken cancellationToken = default!);
+        public Task<ZamuApiResult<ZamupayRoutesDTO>> GetZamupayRoutesAsync(int expirationTime, CancellationToken cancellationToken = default!);
 
-        public Task<(RouteDTO?, ErrorDetailDTO)> GetZamupayRouteAsync(Guid id, int expirationTime, CancellationToken cancellationToken = default!);
+        public Task<ZamuApiResult<RouteDTO>> GetZamupayRouteAsync(Guid id, int expirationTime, CancellationToken cancellationToken = default!);
 
-        public Task<(IEnumerable<RouteDTO>?, ErrorDetailDTO)> GetZamupayRoutesByCategoryAsync(string category, int expirationTime, CancellationToken cancellationToken = default!);
+        public Task<ZamuApiResult<IEnumerable<RouteDTO>>> GetZamupayRoutesByCategoryAsync(string category, int expirationTime, CancellationToken cancellationToken = default!);
 
-        public Task<(IEnumerable<ChannelTypeDTO>?, ErrorDetailDTO)> GetZamupayRouteChannelTypesAsync(Guid id, int expirationTime, CancellationToken cancellationToken = default!);
+        public Task<ZamuApiResult<IEnumerable<ChannelTypeDTO>>> GetZamupayRouteChannelTypesAsync(Guid id, int expirationTime, CancellationToken cancellationToken = default!);
 
         #endregion
 

--- a/Src/ZamuPay.API/Interfaces/IZamupayService.cs
+++ b/Src/ZamuPay.API/Interfaces/IZamupayService.cs
@@ -11,7 +11,7 @@ namespace ZamuPay.API.Interfaces
     {
         #region Identity Server
 
-        public Task<(ZamupayIdentityServerAuthTokenDTO?, ErrorDetailDTO)> GetZamupayIdentityServerAuthTokenAsync(CancellationToken cancellationToken = default!);
+        public Task<ZamuApiResult<ZamupayIdentityServerAuthTokenDTO>> GetZamupayIdentityServerAuthTokenAsync(CancellationToken cancellationToken = default!);
 
         #endregion
 
@@ -29,23 +29,23 @@ namespace ZamuPay.API.Interfaces
 
         #region Payment Orders
 
-        public Task<(PaymentOrderDTO?, object)> GetPaymentOrderAsync(TransactionQueryModelDTO paymentQueryModel, CancellationToken cancellationToken = default!);
+        public Task<ZamuApiResult<PaymentOrderDTO>> GetPaymentOrderAsync(TransactionQueryModelDTO paymentQueryModel, CancellationToken cancellationToken = default!);
 
         #endregion
 
         #region Airtime Purchases
 
-        public Task<(AirtimePurchaseRequestDTO?, object)> PostAirtimePurchaseRequestAsync(AirtimePurchaseRequestDTO paymentQueryModel, CancellationToken cancellationToken = default!);
+        public Task<ZamuApiResult<AirtimePurchaseRequestDTO>> PostAirtimePurchaseRequestAsync(AirtimePurchaseRequestDTO paymentQueryModel, CancellationToken cancellationToken = default!);
 
-        public Task<(PaymentOrderDTO?, object)> GetAirtimePurchaseAsync(TransactionQueryModelDTO paymentQueryModel, CancellationToken cancellationToken = default!);
+        public Task<ZamuApiResult<PaymentOrderDTO>> GetAirtimePurchaseAsync(TransactionQueryModelDTO paymentQueryModel, CancellationToken cancellationToken = default!);
 
         #endregion
 
         #region Bill Payments
 
-        public Task<(BillPaymentSuccessResponseDTO?, object)> PostBillPaymentAsync(BillPaymentDTO billPaymentDTO, CancellationToken cancellationToken = default!);
+        public Task<ZamuApiResult<BillPaymentSuccessResponseDTO>> PostBillPaymentAsync(BillPaymentDTO billPaymentDTO, CancellationToken cancellationToken = default!);
 
-        public Task<(BillPaymentResultDTO?, object)> GetBillPaymentAsync(TransactionQueryModelDTO paymentQueryModel, CancellationToken cancellationToken = default!);
+        public Task<ZamuApiResult<BillPaymentResultDTO>> GetBillPaymentAsync(TransactionQueryModelDTO paymentQueryModel, CancellationToken cancellationToken = default!);
 
         #endregion
     }

--- a/Src/ZamuPay.API/Services/ZamupayService.cs
+++ b/Src/ZamuPay.API/Services/ZamupayService.cs
@@ -27,8 +27,12 @@ namespace ZamuPay.API.Services
 
         #region Identity Server
 
-        public async Task<(ZamupayIdentityServerAuthTokenDTO?, ErrorDetailDTO)> GetZamupayIdentityServerAuthTokenAsync(CancellationToken cancellationToken = default!)
+        public async Task<ZamuApiResult<ZamupayIdentityServerAuthTokenDTO>> GetZamupayIdentityServerAuthTokenAsync(CancellationToken cancellationToken = default!)
         {
+            var result = new ZamuApiResult<ZamupayIdentityServerAuthTokenDTO>();
+
+            var errors = new List<ErrorDetailDTO>();
+
             var requestUrl = $"{_baseUrlConfiguration.Value.IdentityServerBase}connect/token";
 
             try
@@ -37,16 +41,16 @@ namespace ZamuPay.API.Services
 
                 if (redisPayload != null)
                 {
-                    return (Encoding.UTF8.GetString(redisPayload).FromJson<ZamupayIdentityServerAuthTokenDTO>(), null);
+                    return result.Success(Encoding.UTF8.GetString(redisPayload).FromJson<ZamupayIdentityServerAuthTokenDTO>());
                 }
 
                 // Create a dictionary of parameters
                 var parameters = new Dictionary<string, string>
                 {
-                    { "client_id", _baseUrlConfiguration.Value.ClientId },
-                    { "client_secret", _baseUrlConfiguration.Value.ClientSecret },
-                    { "grant_type", _baseUrlConfiguration.Value.GrantType },
-                    { "scope", _baseUrlConfiguration.Value.Scope }
+                    { "client_id", _baseUrlConfiguration.Value.ClientId! },
+                    { "client_secret", _baseUrlConfiguration.Value.ClientSecret! },
+                    { "grant_type", _baseUrlConfiguration.Value.GrantType! },
+                    { "scope", _baseUrlConfiguration.Value.Scope! }
                 };
 
                 // Create a content object with the parameters and the media type
@@ -79,7 +83,7 @@ namespace ZamuPay.API.Services
 
                     await _distributedCache.SetAsync("ZamupayIdentityServerAuthToken", Encoding.UTF8.GetBytes(output), options, cancellationToken);
 
-                    return (zamupayIdentityServerAuthToken, null);
+                    return result.Success(zamupayIdentityServerAuthToken);
                 }
                 else
                 {
@@ -87,15 +91,21 @@ namespace ZamuPay.API.Services
                     {
                         var error = output.FromJson<ErrorDetailDTO>();
 
-                        return (null, error);
+                        errors.Add(error);
+
+                        return result.Failed(errors);
                     }
 
-                    return (null, new ErrorDetailDTO { Title = $"Reason phrase: {response.ReasonPhrase}", Status = (int)response.StatusCode });
+                    errors.Add(new ErrorDetailDTO { Title = $"Reason phrase: {response.ReasonPhrase}", Status = (int)response.StatusCode });
+
+                    return result.Failed(errors);
                 }
             }
             catch (Exception ex)
             {
-                return (null, new ErrorDetailDTO { Status = -1, Title = $"{requestUrl}>ErrorMessage {ex.Message}" });
+                errors.Add(new ErrorDetailDTO { Status = -1, Title = $"{requestUrl}>ErrorMessage {ex.Message}" });
+
+                return result.Failed(errors);
             }
         }
 
@@ -109,13 +119,11 @@ namespace ZamuPay.API.Services
 
             var errors = new List<ErrorDetailDTO>();
 
-            var auth = await this.GetZamupayIdentityServerAuthTokenAsync(cancellationToken);
+            var auth = await GetZamupayIdentityServerAuthTokenAsync(cancellationToken);
 
-            if (auth.Item2 != null)
+            if (!auth.Succeeded)
             {
-                errors.Add(auth.Item2);
-
-                return result.Failed(errors);
+                return result.Failed(auth.Errors);
             }
 
             var requestUrl = $"{_baseUrlConfiguration.Value.ApiBase}v1/transaction-routes/assigned-routes";
@@ -133,9 +141,9 @@ namespace ZamuPay.API.Services
                 var request = new HttpRequestMessage(HttpMethod.Get, "v1/transaction-routes/assigned-routes");
 
                 // Add some custom headers to the request without validation
-                request.Headers.TryAddWithoutValidation("Authorization", $"Bearer {auth.Item1?.AccessToken}");
+                request.Headers.TryAddWithoutValidation("Authorization", $"Bearer {auth.Items?.AccessToken}");
 
-                HttpResponseMessage response = await HttpClientExtensions.SendHttpClientRequestAsync(_httpClientFactory, _baseUrlConfiguration.Value.ApiBase, request, cancellationToken);
+                HttpResponseMessage response = await HttpClientExtensions.SendHttpClientRequestAsync(_httpClientFactory, _baseUrlConfiguration.Value.ApiBase!, request, cancellationToken);
 
                 // Read the response content as a string
                 var output = await response.Content.ReadAsStringAsync();
@@ -231,12 +239,18 @@ namespace ZamuPay.API.Services
 
         #region Payment Orders
 
-        public async Task<(PaymentOrderDTO?, object)> GetPaymentOrderAsync(TransactionQueryModelDTO paymentQueryModel, CancellationToken cancellationToken = default!)
+        public async Task<ZamuApiResult<PaymentOrderDTO>> GetPaymentOrderAsync(TransactionQueryModelDTO paymentQueryModel, CancellationToken cancellationToken = default!)
         {
-            var auth = await this.GetZamupayIdentityServerAuthTokenAsync(cancellationToken);
+            var result = new ZamuApiResult<PaymentOrderDTO>();
 
-            if (auth.Item2 != null)
-                return (null, auth.Item2);
+            var errors = new List<ErrorDetailDTO>();
+
+            var auth = await GetZamupayIdentityServerAuthTokenAsync(cancellationToken);
+
+            if (!auth.Succeeded)
+            {
+                return result.Failed(auth.Errors);
+            }
 
             var requestUrl = $"{_baseUrlConfiguration.Value.ApiBase}v1/payment-order/check-status?Id={paymentQueryModel.Id}&IdType={paymentQueryModel.IdType}";
 
@@ -246,9 +260,9 @@ namespace ZamuPay.API.Services
                 var request = new HttpRequestMessage(HttpMethod.Get, $"v1/payment-order/check-status?Id={paymentQueryModel.Id}&IdType={paymentQueryModel.IdType}");
 
                 // Add some custom headers to the request without validation
-                request.Headers.TryAddWithoutValidation("Authorization", $"Bearer {auth.Item1?.AccessToken}");
+                request.Headers.TryAddWithoutValidation("Authorization", $"Bearer {auth.Items?.AccessToken}");
 
-                HttpResponseMessage response = await HttpClientExtensions.SendHttpClientRequestAsync(_httpClientFactory, _baseUrlConfiguration.Value.ApiBase, request, cancellationToken);
+                HttpResponseMessage response = await HttpClientExtensions.SendHttpClientRequestAsync(_httpClientFactory, _baseUrlConfiguration.Value.ApiBase!, request, cancellationToken);
 
                 // Read the response content as a string
                 var output = await response.Content.ReadAsStringAsync();
@@ -258,7 +272,7 @@ namespace ZamuPay.API.Services
                 {
                     var zamupayRouteCollection = output.FromJson<PaymentOrderDTO>();
 
-                    return (zamupayRouteCollection, null);
+                    return result.Success(zamupayRouteCollection);
                 }
                 else
                 {
@@ -266,15 +280,21 @@ namespace ZamuPay.API.Services
                     {
                         var error = output.FromJson<ErrorDetailDTO>();
 
-                        return (null, error);
+                        errors.Add(error);
+
+                        return result.Failed(errors);
                     }
 
-                    return (null, new ErrorDetailDTO { Title = $"Reason phrase: {response.ReasonPhrase}", Status = (int)response.StatusCode });
+                    errors.Add(new ErrorDetailDTO { Title = $"Reason phrase: {response.ReasonPhrase}", Status = (int)response.StatusCode });
+
+                    return result.Failed(errors);
                 }
             }
             catch (Exception ex)
             {
-                return (null, new ErrorDetailDTO { Status = -1, Title = $"{requestUrl}>ErrorMessage {ex.Message}" });
+                errors.Add(new ErrorDetailDTO { Status = -1, Title = $"{requestUrl}>ErrorMessage {ex.Message}" });
+
+                return result.Failed(errors);
             }
         }
 
@@ -282,17 +302,21 @@ namespace ZamuPay.API.Services
 
         #region Airtime Purchases
 
-        public Task<(AirtimePurchaseRequestDTO?, object)> PostAirtimePurchaseRequestAsync(AirtimePurchaseRequestDTO paymentQueryModel, CancellationToken cancellationToken = default!)
+        public Task<ZamuApiResult<AirtimePurchaseRequestDTO>> PostAirtimePurchaseRequestAsync(AirtimePurchaseRequestDTO paymentQueryModel, CancellationToken cancellationToken = default!)
         {
             throw new NotImplementedException();
         }
 
-        public async Task<(PaymentOrderDTO?, object)> GetAirtimePurchaseAsync(TransactionQueryModelDTO paymentQueryModel, CancellationToken cancellationToken = default!)
+        public async Task<ZamuApiResult<PaymentOrderDTO>> GetAirtimePurchaseAsync(TransactionQueryModelDTO paymentQueryModel, CancellationToken cancellationToken = default!)
         {
-            var auth = await this.GetZamupayIdentityServerAuthTokenAsync(cancellationToken);
+            var result = new ZamuApiResult<PaymentOrderDTO>();
 
-            if (auth.Item2 != null)
-                return (null, auth.Item2);
+            var errors = new List<ErrorDetailDTO>();
+
+            var auth = await GetZamupayIdentityServerAuthTokenAsync(cancellationToken);
+
+            if (!auth.Succeeded)
+                return result.Failed(auth.Errors);
 
             var requestUrl = $"{_baseUrlConfiguration.Value.ApiBase}v1/payment-order/check-status?Id={paymentQueryModel.Id}&IdType={paymentQueryModel.IdType}";
 
@@ -302,9 +326,9 @@ namespace ZamuPay.API.Services
                 var request = new HttpRequestMessage(HttpMethod.Get, $"v1/payment-order/check-status?Id={paymentQueryModel.Id}&IdType={paymentQueryModel.IdType}");
 
                 // Add some custom headers to the request without validation
-                request.Headers.TryAddWithoutValidation("Authorization", $"Bearer {auth.Item1?.AccessToken}");
+                request.Headers.TryAddWithoutValidation("Authorization", $"Bearer {auth.Items?.AccessToken}");
 
-                HttpResponseMessage response = await HttpClientExtensions.SendHttpClientRequestAsync(_httpClientFactory, _baseUrlConfiguration.Value.ApiBase, request, cancellationToken);
+                HttpResponseMessage response = await HttpClientExtensions.SendHttpClientRequestAsync(_httpClientFactory, _baseUrlConfiguration.Value.ApiBase!, request, cancellationToken);
 
                 // Read the response content as a string
                 var output = await response.Content.ReadAsStringAsync();
@@ -314,7 +338,7 @@ namespace ZamuPay.API.Services
                 {
                     var zamupayRouteCollection = output.FromJson<PaymentOrderDTO>();
 
-                    return (zamupayRouteCollection, null);
+                    return result.Success(zamupayRouteCollection);
                 }
                 else
                 {
@@ -322,15 +346,21 @@ namespace ZamuPay.API.Services
                     {
                         var error = output.FromJson<ErrorDetailDTO>();
 
-                        return (null, error);
+                        errors.Add(error);
+
+                        return result.Failed(errors);
                     }
 
-                    return (null, new ErrorDetailDTO { Title = $"Reason phrase: {response.ReasonPhrase}", Status = (int)response.StatusCode });
+                    errors.Add(new ErrorDetailDTO { Title = $"Reason phrase: {response.ReasonPhrase}", Status = (int)response.StatusCode });
+
+                    return result.Failed(errors);
                 }
             }
             catch (Exception ex)
             {
-                return (null, new ErrorDetailDTO { Status = -1, Title = $"{requestUrl}>ErrorMessage {ex.Message}" });
+                errors.Add(new ErrorDetailDTO { Status = -1, Title = $"{requestUrl}>ErrorMessage {ex.Message}" });
+
+                return result.Failed(errors);
             }
         }
 
@@ -338,12 +368,16 @@ namespace ZamuPay.API.Services
 
         #region Bill Payments
 
-        public async Task<(BillPaymentSuccessResponseDTO?, object)> PostBillPaymentAsync(BillPaymentDTO billPaymentDTO, CancellationToken cancellationToken = default!)
+        public async Task<ZamuApiResult<BillPaymentSuccessResponseDTO>> PostBillPaymentAsync(BillPaymentDTO billPaymentDTO, CancellationToken cancellationToken = default!)
         {
-            var auth = await this.GetZamupayIdentityServerAuthTokenAsync(cancellationToken);
+            var result = new ZamuApiResult<BillPaymentSuccessResponseDTO>();
 
-            if (auth.Item2 != null)
-                return (null, auth.Item2);
+            var errors = new List<ErrorDetailDTO>();
+
+            var auth = await GetZamupayIdentityServerAuthTokenAsync(cancellationToken);
+
+            if (!auth.Succeeded)
+                return result.Failed(auth.Errors);
 
             var requestUrl = $"{_baseUrlConfiguration.Value.ApiBase}v1/bill-payments";
 
@@ -359,10 +393,10 @@ namespace ZamuPay.API.Services
 
                 // Add some custom headers to the request without validation
                 request.Headers.TryAddWithoutValidation("Content-Type", "application/json");
-                request.Headers.TryAddWithoutValidation("Authorization", $"Bearer {auth.Item1?.AccessToken}");
+                request.Headers.TryAddWithoutValidation("Authorization", $"Bearer {auth.Items?.AccessToken}");
                 request.Headers.TryAddWithoutValidation("Accept", "text/plain");
 
-                HttpResponseMessage response = await HttpClientExtensions.SendHttpClientRequestAsync(_httpClientFactory, _baseUrlConfiguration.Value.ApiBase, request, cancellationToken);
+                HttpResponseMessage response = await HttpClientExtensions.SendHttpClientRequestAsync(_httpClientFactory, _baseUrlConfiguration.Value.ApiBase!, request, cancellationToken);
 
                 // Read the response content as a string
                 var output = await response.Content.ReadAsStringAsync();
@@ -372,7 +406,7 @@ namespace ZamuPay.API.Services
                 {
                     var zamupayRouteCollection = output.FromJson<BillPaymentSuccessResponseDTO>();
 
-                    return (zamupayRouteCollection, null);
+                    return result.Success(zamupayRouteCollection);
                 }
                 else
                 {
@@ -380,24 +414,34 @@ namespace ZamuPay.API.Services
                     {
                         var error = output.FromJson<ErrorDetailDTO>();
 
-                        return (null, error);
+                        errors.Add(error);
+
+                        return result.Failed(errors);
                     }
 
-                    return (null, new ErrorDetailDTO { Title = $"Reason phrase: {response.ReasonPhrase}", Status = (int)response.StatusCode });
+                    errors.Add(new ErrorDetailDTO { Title = $"Reason phrase: {response.ReasonPhrase}", Status = (int)response.StatusCode });
+
+                    return result.Failed(errors);
                 }
             }
             catch (Exception ex)
             {
-                return (null, new ErrorDetailDTO { Status = -1, Title = $"{requestUrl}>ErrorMessage {ex.Message}" });
+                errors.Add(new ErrorDetailDTO { Status = -1, Title = $"{requestUrl}>ErrorMessage {ex.Message}" });
+
+                return result.Failed(errors);
             }
         }
 
-        public async Task<(BillPaymentResultDTO?, object)> GetBillPaymentAsync(TransactionQueryModelDTO paymentQueryModel, CancellationToken cancellationToken = default!)
+        public async Task<ZamuApiResult<BillPaymentResultDTO>> GetBillPaymentAsync(TransactionQueryModelDTO paymentQueryModel, CancellationToken cancellationToken = default!)
         {
+            var result = new ZamuApiResult<BillPaymentResultDTO>();
+
+            var errors = new List<ErrorDetailDTO>();
+
             var auth = await this.GetZamupayIdentityServerAuthTokenAsync(cancellationToken);
 
-            if (auth.Item2 != null)
-                return (null, auth.Item2);
+            if (!auth.Succeeded)
+                return result.Failed(auth.Errors);
 
             var requestUrl = $"{_baseUrlConfiguration.Value.ApiBase}v1/bill-payments?{paymentQueryModel.IdType}={paymentQueryModel.Id}";
 
@@ -407,9 +451,9 @@ namespace ZamuPay.API.Services
                 var request = new HttpRequestMessage(HttpMethod.Get, $"v1/bill-payments?{paymentQueryModel.IdType}={paymentQueryModel.Id}");
 
                 // Add some custom headers to the request without validation
-                request.Headers.TryAddWithoutValidation("Authorization", $"Bearer {auth.Item1?.AccessToken}");
+                request.Headers.TryAddWithoutValidation("Authorization", $"Bearer {auth.Items?.AccessToken}");
 
-                HttpResponseMessage response = await HttpClientExtensions.SendHttpClientRequestAsync(_httpClientFactory, _baseUrlConfiguration.Value.ApiBase, request, cancellationToken);
+                HttpResponseMessage response = await HttpClientExtensions.SendHttpClientRequestAsync(_httpClientFactory, _baseUrlConfiguration.Value.ApiBase!, request, cancellationToken);
 
                 // Read the response content as a string
                 var output = await response.Content.ReadAsStringAsync();
@@ -419,7 +463,7 @@ namespace ZamuPay.API.Services
                 {
                     var zamupayRouteCollection = output.FromJson<BillPaymentResultDTO>();
 
-                    return (zamupayRouteCollection, null);
+                    return result.Success(zamupayRouteCollection);
                 }
                 else
                 {
@@ -427,15 +471,21 @@ namespace ZamuPay.API.Services
                     {
                         var error = output.FromJson<ErrorDetailDTO>();
 
-                        return (null, error);
+                        errors.Add(error);
+
+                        return result.Failed(errors);
                     }
 
-                    return (null, new ErrorDetailDTO { Title = $"Reason phrase: {response.ReasonPhrase}", Status = (int)response.StatusCode });
+                    errors.Add(new ErrorDetailDTO { Title = $"Reason phrase: {response.ReasonPhrase}", Status = (int)response.StatusCode });
+
+                    return result.Failed(errors);
                 }
             }
             catch (Exception ex)
             {
-                return (null, new ErrorDetailDTO { Status = -1, Title = $"{requestUrl}>ErrorMessage {ex.Message}" });
+                errors.Add(new ErrorDetailDTO { Status = -1, Title = $"{requestUrl}>ErrorMessage {ex.Message}" });
+
+                return result.Failed(errors);
             }
         }
 


### PR DESCRIPTION
- remove use of tuples for results but delegate it to new ZamuApiResult class
- clean up example application